### PR TITLE
Code cleanup

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,4 +2,4 @@ version: 1
 update_configs:
   - package_manager: "java:gradle"
     directory: "/"
-    update_schedule: "weekly"
+    update_schedule: "monthly"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -34,7 +34,6 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 }
 
 withPipeline(type , product, component) {
-    enableDockerBuild()
     installCharts()
     enableAksStagingDeployment()
     loadVaultSecrets(secrets)

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,7 @@ def versions = [
         junit                   : '4.12',
         lombok                  : '1.18.4',
         reformHealth            : '0.0.5',
+        reformAppinsights       : '5.1.1',
         reformJavaLogging       : '5.0.1',
         reformPropertiesVolume  : '0.0.4',
         restAssured             : '3.0.3',
@@ -146,7 +147,7 @@ dependencies {
   compile group: 'org.springframework.boot', name: 'spring-boot-starter-web', version: versions.springBoot
   compile group: 'org.springframework.retry', name: 'spring-retry', version: versions.springRetry
   compile group: 'uk.gov.service.notify', name: 'notifications-java-client', version: versions.hmctsNotify
-  compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformJavaLogging
+  compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformAppinsights
   compile group: 'uk.gov.hmcts.reform', name: 'health-spring-boot-starter', version: versions.reformHealth
   compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: versions.reformPropertiesVolume
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    springBootVersion = '2.1.3.RELEASE'
+    springBootVersion = '2.2.4.RELEASE'
   }
   repositories {
     jcenter()
@@ -13,7 +13,7 @@ buildscript {
   dependencies {
     classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
     classpath group: 'org.sonarsource.scanner.gradle', name: 'sonarqube-gradle-plugin', version: '2.7.1'
-    classpath("net.serenity-bdd:serenity-gradle-plugin:2.0.83")
+    classpath("net.serenity-bdd:serenity-gradle-plugin:2.0.90")
   }
 }
 
@@ -21,12 +21,12 @@ plugins {
   id 'application'
   id 'checkstyle'
   id 'io.franzbecker.gradle-lombok' version '1.14'
-  id 'io.spring.dependency-management' version '1.0.8.RELEASE'
+  id 'io.spring.dependency-management' version '1.0.9.RELEASE'
   id 'info.solidsoft.pitest' version '1.4.6'
   id 'jacoco'
   id 'org.owasp.dependencycheck' version '5.2.4'
   id 'org.sonarqube' version '2.8'
-  id 'org.springframework.boot' version '2.1.3.RELEASE'
+  id 'org.springframework.boot' version '2.2.4.RELEASE'
 }
 
 apply plugin: 'java'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -13,38 +13,9 @@
         <cve>CVE-2018-1258</cve>
     </suppress>
     <suppress>
-        <notes>We are using SecureRandom without a custom seed so not affected. This will however be
-            fixed with spring boot 2.1.4 upgrade which is using spring-security.* of 5.1.5 or higher
-        </notes>
-        <gav regex="true">.*</gav>
-        <cve>CVE-2019-3795</cve>
-    </suppress>
-    <suppress>
-        <notes>Ignore checkstyle</notes>
-        <gav regex="true">.*</gav>
-        <cve>CVE-2019-9658</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-            This is exploitable in com.zaxxer.hikari.HikariConfig and com.zaxxer.hikari.HikariDataSource
-            which we do not use. Pending the release of a stable jackson databind version (>2.9.9.3) ]]>
-        </notes>
-        <gav regex="true">.*</gav>
-        <cve>CVE-2019-14540</cve>
-        <cve>CVE-2019-16335</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-			Netty before 4.1.42.
-			]]></notes>
-        <gav regex="true">.*</gav>
-        <cve>CVE-2019-16869</cve>
-        <cve>CVE-2015-2156</cve>
-        <cve>CVE-2014-3488</cve>
-    </suppress>
-    <suppress>
         <notes>All versions of com.puppycrawl.tools:checkstyle before 8.29 are vulnerable to
             XML External Entity (XXE) Injection due to an incomplete fix for CVE-2019-9658. </notes>
+        <cve>CVE-2019-9658</cve>
         <cve>CVE-2019-10782</cve>
     </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -42,4 +42,9 @@
         <cve>CVE-2015-2156</cve>
         <cve>CVE-2014-3488</cve>
     </suppress>
+    <suppress>
+        <notes>All versions of com.puppycrawl.tools:checkstyle before 8.29 are vulnerable to
+            XML External Entity (XXE) Injection due to an incomplete fix for CVE-2019-9658. </notes>
+        <cve>CVE-2019-10782</cve>
+    </suppress>
 </suppressions>

--- a/src/functionalTests/java/uk/gov/hmcts/reform/finrem/functional/notification/NotificationTests.java
+++ b/src/functionalTests/java/uk/gov/hmcts/reform/finrem/functional/notification/NotificationTests.java
@@ -19,42 +19,30 @@ public class NotificationTests extends IntegrationTestBase {
     @Value("${notification.uri}")
     private String notificationUrl;
 
-
     @Test
     public void verifyNotifyAssignToJudgeTestIsOkay() {
-
         validatePostSuccessForNotification(NOTIFY_ASSIGN_TO_JUDGE, "assignedToJudge.json");
-
     }
 
     @Test
     public void verifyNotifyConsentOrderAvailableTestIsOkay() {
-
         validatePostSuccessForNotification(CONSENT_ORDER_AVAILABLE, "consentOrderAvailable.json");
-
     }
 
     @Test
     public void verifyNotifyConsentOrderMadeTestIsOkay() {
-
         validatePostSuccessForNotification(CONSENT_ORDER_MADE, "consentOrderMade.json");
-
     }
 
     @Test
     public void verifyNotifyConsentOrderNotApprovedTestIsOkay() {
-
         validatePostSuccessForNotification(CONSENT_ORDER_NOT_APPROVED, "consentOrderNotApproved.json");
-
     }
 
     @Test
     public void verifyNotifyHwfSuccessfulTestIsOkay() {
-
         validatePostSuccessForNotification(HWF_SUCCESSFUL_API_URI, "hwfSuccessfulEmail.json");
-
     }
-
 
     private void validatePostSuccessForNotification(String url, String jsonFileName) {
 
@@ -64,8 +52,5 @@ public class NotificationTests extends IntegrationTestBase {
                 .body(utils.getJsonFromFile(jsonFileName))
                 .when().post(notificationUrl + url)
                 .then().assertThat().statusCode(204);
-
     }
-
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/notifications/NotificationApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/notifications/NotificationApplication.java
@@ -22,5 +22,4 @@ public class NotificationApplication {
         loggingFilter.setMaxPayloadLength(10240);
         return loggingFilter;
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/finrem/notifications/NotificationConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/finrem/notifications/NotificationConstants.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.reform.finrem.notifications;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationConstants {
+
+    // Authentication
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+}

--- a/src/smokeTest/java/uk/gov/hmcts/reform/finrem/notification/smoketests/SmokeTestConfiguration.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/finrem/notification/smoketests/SmokeTestConfiguration.java
@@ -5,5 +5,5 @@ import org.springframework.context.annotation.PropertySource;
 
 @ComponentScan("uk.gov.hmcts.reform.finrem.notification")
 @PropertySource("application.properties")
-public class SmokeTestConfiguration {
+class SmokeTestConfiguration {
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/TestConstants.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/TestConstants.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.finrem.notifications;
+
+public class TestConstants {
+    public static final String TEST_CASE_FAMILY_MAN_ID = "test.family.man.id";
+    public static final String TEST_SOLICITOR_REFERENCE = "test.solicitor.reference";
+    public static final String TEST_SOLICITOR_NAME = "Solicitor name";
+    public static final String TEST_SOLICITOR_EMAIL = "testSolicitor@email.com";
+    public static final String BEARER_AUTH_TOKEN = "Bearer test.auth.token";
+}

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/controllers/NotificationControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/controllers/NotificationControllerTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.finrem.notifications.NotificationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.BEARER_AUTH_TOKEN;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(NotificationController.class)
@@ -47,8 +49,6 @@ public class NotificationControllerTest {
 
     private MockMvc mvc;
 
-    private static final String BEARER_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9";
-
     @Before
     public void setUp() {
         mvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
@@ -62,9 +62,10 @@ public class NotificationControllerTest {
 
         mvc.perform(post(NOTIFY_HWF_SUCCESSFUL_URL)
                 .content(request.toString())
-                .header("Authorization", BEARER_TOKEN)
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
+
         verify(emailService, times(1))
                 .sendConfirmationEmail(any(NotificationRequest.class), any(EmailTemplateNames.class));
     }
@@ -77,12 +78,12 @@ public class NotificationControllerTest {
 
         mvc.perform(post(NOTIFY_ASSIGN_TO_JUDGE_URL)
                 .content(request.toString())
-                .header("Authorization", BEARER_TOKEN)
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
+
         verify(emailService, times(1))
                 .sendConfirmationEmail(any(NotificationRequest.class), any(EmailTemplateNames.class));
-
     }
 
     @Test
@@ -93,12 +94,12 @@ public class NotificationControllerTest {
 
         mvc.perform(post(NOTIFY_CONSENT_ORDER_MADE_URL)
                 .content(request.toString())
-                .header("Authorization", BEARER_TOKEN)
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
+
         verify(emailService, times(1))
                 .sendConfirmationEmail(any(NotificationRequest.class), any(EmailTemplateNames.class));
-
     }
 
     @Test
@@ -109,12 +110,12 @@ public class NotificationControllerTest {
 
         mvc.perform(post(NOTIFY_CONSENT_ORDER_NOT_APPROVED_URL)
                 .content(request.toString())
-                .header("Authorization", BEARER_TOKEN)
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
+
         verify(emailService, times(1))
                 .sendConfirmationEmail(any(NotificationRequest.class), any(EmailTemplateNames.class));
-
     }
 
     @Test
@@ -125,12 +126,12 @@ public class NotificationControllerTest {
 
         mvc.perform(post(NOTIFY_CONSENT_ORDER_AVAILABLE_URL)
                 .content(request.toString())
-                .header("Authorization", BEARER_TOKEN)
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
+
         verify(emailService, times(1))
                 .sendConfirmationEmail(any(NotificationRequest.class), any(EmailTemplateNames.class));
-
     }
 
     @Test
@@ -141,11 +142,11 @@ public class NotificationControllerTest {
 
         mvc.perform(post(NOTIFY_CONTESTED_HWF_SUCCESSFUL_URL)
                 .content(request.toString())
-                .header("Authorization", BEARER_TOKEN)
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
+
         verify(emailService, times(1))
                 .sendConfirmationEmail(any(NotificationRequest.class), any(EmailTemplateNames.class));
-
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/domain/NotificationRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/domain/NotificationRequestTest.java
@@ -34,26 +34,24 @@ public class NotificationRequestTest {
     public void shouldSetAndGetHwfNotificationRequestData() {
         underTest = new NotificationRequest();
         setNotificationData();
-        assertNotifcationData();
+        assertNotificationData();
     }
 
-    private void assertNotifcationData() {
+    private void assertNotificationData() {
         assertEquals("case1234", underTest.getCaseReferenceNumber());
         assertEquals("123123", underTest.getSolicitorReferenceNumber());
         assertEquals("Prashanth", underTest.getName());
         assertEquals("test1@test1.com", underTest.getNotificationEmail());
     }
 
-
     @Test
     public void shouldSetAndGetHwfNotificationRequestDataForContested() {
         underTest = new NotificationRequest();
         setNotificationData();
         underTest.setSelectedCourt("nottingham");
-        assertNotifcationData();
+        assertNotificationData();
         assertEquals("nottingham", underTest.getSelectedCourt());
     }
-
 
     private void setNotificationData() {
         underTest.setName("Prashanth");

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/integrationtest/NotifyAssignToJudgeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/integrationtest/NotifyAssignToJudgeTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.finrem.notifications.integrationtest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -24,6 +24,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.finrem.notifications.NotificationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.BEARER_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_CASE_FAMILY_MAN_ID;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_EMAIL;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_REFERENCE;
+import static uk.gov.hmcts.reform.finrem.notifications.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = NotificationApplication.class)
@@ -32,10 +39,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureMockMvc
 public class NotifyAssignToJudgeTest {
-    private static final String AUTHORIZATION = "Authorization";
+
     private static final String NOTIFY_ASSIGN_TO_JUDGE = "/notify/assign-to-judge";
-    private static final String BEARER_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9";
-    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired
     private MockMvc webClient;
@@ -43,18 +48,25 @@ public class NotifyAssignToJudgeTest {
     @MockBean
     private EmailClient emailClient;
 
+    private NotificationRequest notificationRequest;
+
+    @Before
+    public void setUp() {
+        notificationRequest = new NotificationRequest();
+        notificationRequest.setNotificationEmail(TEST_SOLICITOR_EMAIL);
+        notificationRequest.setCaseReferenceNumber(TEST_CASE_FAMILY_MAN_ID);
+        notificationRequest.setSolicitorReferenceNumber(TEST_SOLICITOR_REFERENCE);
+        notificationRequest.setName(TEST_SOLICITOR_NAME);
+    }
+
     @Test
     public void givenCaseData_whenAssignToJudge_ThenShouldSendNotificationSuccessfully() throws Exception {
-        NotificationRequest notificationRequest = new NotificationRequest();
-        notificationRequest.setNotificationEmail("test1@test.com");
-        notificationRequest.setCaseReferenceNumber("EZ00110001");
-        notificationRequest.setSolicitorReferenceNumber("LL02");
-        notificationRequest.setName("Test");
+        notificationRequest.setName(TEST_SOLICITOR_NAME);
 
         webClient.perform(post(NOTIFY_ASSIGN_TO_JUDGE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(convertObjectToJsonString(notificationRequest))
-                .header(AUTHORIZATION, BEARER_TOKEN))
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN))
                 .andExpect(status().isNoContent());
 
         verify(emailClient, Mockito.times(1))
@@ -63,27 +75,13 @@ public class NotifyAssignToJudgeTest {
 
     @Test
     public void givenCaseData_whenAssignToJudgeAndThrowsNotificationException() throws Exception {
-        NotificationRequest notificationRequest = new NotificationRequest();
-        notificationRequest.setNotificationEmail("test1@test.com");
-        notificationRequest.setCaseReferenceNumber("EZ00110001");
-        notificationRequest.setSolicitorReferenceNumber("LL02");
         when(emailClient.sendEmail(anyString(), anyString(), Mockito.anyMap(), anyString()))
                 .thenThrow(new NotificationClientException(new Exception("Sending Email Failed ")));
 
         webClient.perform(post(NOTIFY_ASSIGN_TO_JUDGE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(convertObjectToJsonString(notificationRequest))
-                .header(AUTHORIZATION, BEARER_TOKEN))
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN))
                 .andExpect(status().isNoContent());
-    }
-
-
-    private String convertObjectToJsonString(final Object object) {
-
-        try {
-            return objectMapper.writeValueAsString(object);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/integrationtest/NotifyConsentOrderAvailableTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/integrationtest/NotifyConsentOrderAvailableTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.finrem.notifications.integrationtest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +24,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.finrem.notifications.NotificationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.BEARER_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_CASE_FAMILY_MAN_ID;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_EMAIL;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_REFERENCE;
+import static uk.gov.hmcts.reform.finrem.notifications.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = NotificationApplication.class)
@@ -33,10 +39,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureMockMvc
 public class NotifyConsentOrderAvailableTest {
-    private static final String AUTHORIZATION = "Authorization";
+
     private static final String CONSENT_ORDER_AVAILABLE = "/notify/consent-order-available";
-    private static final String BEARER_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9";
-    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired
     private MockMvc webClient;
@@ -49,11 +53,10 @@ public class NotifyConsentOrderAvailableTest {
     @Before
     public void setUp() {
         notificationRequest = new NotificationRequest();
-        notificationRequest.setNotificationEmail("test2@test.com");
-        notificationRequest.setCaseReferenceNumber("EZ00110002");
-        notificationRequest.setSolicitorReferenceNumber("LL03");
-        notificationRequest.setName("Test");
-
+        notificationRequest.setNotificationEmail(TEST_SOLICITOR_EMAIL);
+        notificationRequest.setCaseReferenceNumber(TEST_CASE_FAMILY_MAN_ID);
+        notificationRequest.setSolicitorReferenceNumber(TEST_SOLICITOR_REFERENCE);
+        notificationRequest.setName(TEST_SOLICITOR_NAME);
     }
 
     @Test
@@ -62,7 +65,7 @@ public class NotifyConsentOrderAvailableTest {
         webClient.perform(post(CONSENT_ORDER_AVAILABLE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(convertObjectToJsonString(notificationRequest))
-                .header(AUTHORIZATION, BEARER_TOKEN))
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN))
                 .andExpect(status().isNoContent());
 
         verify(emailClient, Mockito.times(1))
@@ -76,16 +79,7 @@ public class NotifyConsentOrderAvailableTest {
         webClient.perform(post(CONSENT_ORDER_AVAILABLE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(convertObjectToJsonString(notificationRequest))
-                .header(AUTHORIZATION, BEARER_TOKEN))
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN))
                 .andExpect(status().isNoContent());
-    }
-
-
-    private String convertObjectToJsonString(final Object object) {
-        try {
-            return objectMapper.writeValueAsString(object);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/integrationtest/NotifyConsentOrderMadeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/integrationtest/NotifyConsentOrderMadeTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.finrem.notifications.integrationtest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -24,6 +24,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.finrem.notifications.NotificationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.BEARER_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_CASE_FAMILY_MAN_ID;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_EMAIL;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_REFERENCE;
+import static uk.gov.hmcts.reform.finrem.notifications.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = NotificationApplication.class)
@@ -32,10 +39,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureMockMvc
 public class NotifyConsentOrderMadeTest {
-    private static final String AUTHORIZATION = "Authorization";
+
     private static final String CONSENT_ORDER_MADE = "/notify/consent-order-made";
-    private static final String BEARER_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9";
-    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired
     private MockMvc webClient;
@@ -43,18 +48,24 @@ public class NotifyConsentOrderMadeTest {
     @MockBean
     private EmailClient emailClient;
 
+    private NotificationRequest notificationRequest;
+
+    @Before
+    public void setUp() {
+        notificationRequest = new NotificationRequest();
+        notificationRequest.setNotificationEmail(TEST_SOLICITOR_EMAIL);
+        notificationRequest.setCaseReferenceNumber(TEST_CASE_FAMILY_MAN_ID);
+        notificationRequest.setSolicitorReferenceNumber(TEST_SOLICITOR_REFERENCE);
+    }
+
     @Test
     public void givenCaseData_whenNotifyConsentOrderMade_ThenShouldSendHwfNotificationSuccessfully() throws Exception {
-        NotificationRequest notificationRequest = new NotificationRequest();
-        notificationRequest.setNotificationEmail("test2@test.com");
-        notificationRequest.setCaseReferenceNumber("EZ00110002");
-        notificationRequest.setSolicitorReferenceNumber("LL03");
-        notificationRequest.setName("Test");
+        notificationRequest.setName(TEST_SOLICITOR_NAME);
 
         webClient.perform(post(CONSENT_ORDER_MADE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(convertObjectToJsonString(notificationRequest))
-                .header(AUTHORIZATION, BEARER_TOKEN))
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN))
                 .andExpect(status().isNoContent());
 
         verify(emailClient, Mockito.times(1))
@@ -63,27 +74,13 @@ public class NotifyConsentOrderMadeTest {
 
     @Test
     public void givenCaseData_whenNotifyConsentOrderMadeAndThrowsNotificationException() throws Exception {
-        NotificationRequest notificationRequest = new NotificationRequest();
-        notificationRequest.setNotificationEmail("test2@test.com");
-        notificationRequest.setCaseReferenceNumber("EZ00110002");
-        notificationRequest.setSolicitorReferenceNumber("LL03");
         when(emailClient.sendEmail(anyString(), anyString(), Mockito.anyMap(), anyString()))
                 .thenThrow(new NotificationClientException(new Exception("Sending Email Failed ")));
 
         webClient.perform(post(CONSENT_ORDER_MADE)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(convertObjectToJsonString(notificationRequest))
-                .header(AUTHORIZATION, BEARER_TOKEN))
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN))
                 .andExpect(status().isNoContent());
-    }
-
-
-    private String convertObjectToJsonString(final Object object) {
-
-        try {
-            return objectMapper.writeValueAsString(object);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/integrationtest/NotifyHwfSuccessfulTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/integrationtest/NotifyHwfSuccessfulTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.finrem.notifications.integrationtest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -24,6 +24,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.finrem.notifications.NotificationConstants.AUTHORIZATION_HEADER;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.BEARER_AUTH_TOKEN;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_CASE_FAMILY_MAN_ID;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_EMAIL;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_REFERENCE;
+import static uk.gov.hmcts.reform.finrem.notifications.testutil.ObjectMapperTestUtil.convertObjectToJsonString;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = NotificationApplication.class)
@@ -32,10 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @AutoConfigureMockMvc
 public class NotifyHwfSuccessfulTest {
-    private static final String AUTHORIZATION = "Authorization";
     private static final String HWF_SUCCESSFUL_API_URI = "/notify/hwf-successful";
-    private static final String BEARER_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9";
-    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired
     private MockMvc webClient;
@@ -43,18 +47,24 @@ public class NotifyHwfSuccessfulTest {
     @MockBean
     private EmailClient emailClient;
 
+    private NotificationRequest notificationRequest;
+
+    @Before
+    public void setUp() {
+        notificationRequest = new NotificationRequest();
+        notificationRequest.setNotificationEmail(TEST_SOLICITOR_EMAIL);
+        notificationRequest.setCaseReferenceNumber(TEST_CASE_FAMILY_MAN_ID);
+        notificationRequest.setSolicitorReferenceNumber(TEST_SOLICITOR_REFERENCE);
+    }
+
     @Test
     public void givenCaseData_whenNotifyHwfSuccessful_ThenShouldSendHwfNotificationSuccessfully() throws Exception {
-        NotificationRequest hwfSuccessfulNotificationRequest = new NotificationRequest();
-        hwfSuccessfulNotificationRequest.setNotificationEmail("test@test.com");
-        hwfSuccessfulNotificationRequest.setCaseReferenceNumber("EZ00110000");
-        hwfSuccessfulNotificationRequest.setSolicitorReferenceNumber("LL02");
-        hwfSuccessfulNotificationRequest.setName("Test");
+        notificationRequest.setName(TEST_SOLICITOR_NAME);
 
         webClient.perform(post(HWF_SUCCESSFUL_API_URI)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(convertObjectToJsonString(hwfSuccessfulNotificationRequest))
-                .header(AUTHORIZATION, BEARER_TOKEN))
+                .content(convertObjectToJsonString(notificationRequest))
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN))
                 .andExpect(status().isNoContent());
 
         verify(emailClient, Mockito.times(1))
@@ -63,27 +73,13 @@ public class NotifyHwfSuccessfulTest {
 
     @Test
     public void givenCaseData_whenNotifyHwfSuccessfulAndThrowsNotificationException() throws Exception {
-        NotificationRequest hwfSuccessfulNotificationRequest = new NotificationRequest();
-        hwfSuccessfulNotificationRequest.setNotificationEmail("test@test.com");
-        hwfSuccessfulNotificationRequest.setCaseReferenceNumber("EZ00110000");
-        hwfSuccessfulNotificationRequest.setSolicitorReferenceNumber("LL02");
         when(emailClient.sendEmail(anyString(), anyString(), Mockito.anyMap(), anyString()))
                 .thenThrow(new NotificationClientException(new Exception("Sending Email Failed ")));
 
         webClient.perform(post(HWF_SUCCESSFUL_API_URI)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(convertObjectToJsonString(hwfSuccessfulNotificationRequest))
-                .header(AUTHORIZATION, BEARER_TOKEN))
+                .content(convertObjectToJsonString(notificationRequest))
+                .header(AUTHORIZATION_HEADER, BEARER_AUTH_TOKEN))
                 .andExpect(status().isNoContent());
-    }
-
-
-    private String convertObjectToJsonString(final Object object) {
-
-        try {
-            return objectMapper.writeValueAsString(object);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/service/EmailServiceTest.java
@@ -24,6 +24,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.springframework.util.StringUtils.isEmpty;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_CASE_FAMILY_MAN_ID;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_EMAIL;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_NAME;
+import static uk.gov.hmcts.reform.finrem.notifications.TestConstants.TEST_SOLICITOR_REFERENCE;
 import static uk.gov.hmcts.reform.finrem.notifications.domain.EmailTemplateNames.FR_ASSIGNED_TO_JUDGE;
 import static uk.gov.hmcts.reform.finrem.notifications.domain.EmailTemplateNames.FR_CONSENT_ORDER_AVAILABLE;
 import static uk.gov.hmcts.reform.finrem.notifications.domain.EmailTemplateNames.FR_CONSENT_ORDER_MADE;
@@ -57,10 +61,10 @@ public class EmailServiceTest {
     @Before
     public void setUp() {
         notificationRequest = new NotificationRequest();
-        notificationRequest.setNotificationEmail(EMAIL_ADDRESS);
-        notificationRequest.setCaseReferenceNumber("12345");
-        notificationRequest.setSolicitorReferenceNumber("56789");
-        notificationRequest.setName("Padmaja Ramisetti");
+        notificationRequest.setNotificationEmail(TEST_SOLICITOR_EMAIL);
+        notificationRequest.setCaseReferenceNumber(TEST_CASE_FAMILY_MAN_ID);
+        notificationRequest.setSolicitorReferenceNumber(TEST_SOLICITOR_REFERENCE);
+        notificationRequest.setName(TEST_SOLICITOR_NAME);
     }
 
     @Test
@@ -206,7 +210,6 @@ public class EmailServiceTest {
                 eq(expectedEmailTemplateVars),
                 anyString());
     }
-
 
     @Test
     public void sendConsentOrderAvailableEmailShouldNotPropagateNotificationClientException()

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/service/EmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/service/EmailServiceTest.java
@@ -39,7 +39,6 @@ import static uk.gov.hmcts.reform.finrem.notifications.domain.EmailTemplateNames
 @TestPropertySource(locations = "/application.properties")
 @Slf4j
 public class EmailServiceTest {
-    private static final String EMAIL_ADDRESS = "simulate-delivered@notifications.service.gov.uk";
 
     @MockBean
     private EmailClient mockClient;
@@ -77,7 +76,7 @@ public class EmailServiceTest {
 
         verify(mockClient).sendEmail(
                 eq(emailTemplates.get(FR_HWF_SUCCESSFUL.name())),
-                eq(EMAIL_ADDRESS),
+                eq(TEST_SOLICITOR_EMAIL),
                 eq(expectedEmailTemplateVars),
                 anyString());
     }
@@ -93,7 +92,7 @@ public class EmailServiceTest {
 
         verify(mockClient).sendEmail(
                 eq(emailTemplates.get(FR_HWF_SUCCESSFUL.name())),
-                eq(EMAIL_ADDRESS),
+                eq(TEST_SOLICITOR_EMAIL),
                 eq(expectedEmailTemplateVars),
                 anyString());
     }
@@ -125,7 +124,7 @@ public class EmailServiceTest {
 
         verify(mockClient).sendEmail(
                 eq(emailTemplates.get(FR_ASSIGNED_TO_JUDGE.name())),
-                eq(EMAIL_ADDRESS),
+                eq(TEST_SOLICITOR_EMAIL),
                 eq(expectedEmailTemplateVars),
                 anyString());
     }
@@ -145,6 +144,7 @@ public class EmailServiceTest {
     @Test
     public void sendConsentOrderMadeConfirmationEmailShouldCallTheEmailClientToSendAnEmail()
             throws NotificationClientException {
+
         Map<String, String> expectedEmailTemplateVars = getEmailTemplateVars();
         expectedEmailTemplateVars.putAll(emailTemplateVars.get(FR_CONSENT_ORDER_MADE.name()));
 
@@ -152,7 +152,7 @@ public class EmailServiceTest {
 
         verify(mockClient).sendEmail(
                 eq(emailTemplates.get(FR_CONSENT_ORDER_MADE.name())),
-                eq(EMAIL_ADDRESS),
+                eq(TEST_SOLICITOR_EMAIL),
                 eq(expectedEmailTemplateVars),
                 anyString());
     }
@@ -160,6 +160,7 @@ public class EmailServiceTest {
     @Test
     public void sendConsentOrderMadeConfirmationEmailShouldNotPropagateNotificationClientException()
             throws NotificationClientException {
+
         doThrow(new NotificationClientException(new Exception("Exception inception")))
                 .when(mockClient).sendEmail(anyString(), anyString(), eq(null), anyString());
         try {
@@ -172,6 +173,7 @@ public class EmailServiceTest {
     @Test
     public void sendConsentOrderNotApprovedEmailShouldCallTheEmailClientToSendAnEmail()
             throws NotificationClientException {
+
         Map<String, String> expectedEmailTemplateVars = getEmailTemplateVars();
         expectedEmailTemplateVars.putAll(emailTemplateVars.get(FR_CONSENT_ORDER_NOT_APPROVED.name()));
 
@@ -179,7 +181,7 @@ public class EmailServiceTest {
 
         verify(mockClient).sendEmail(
                 eq(emailTemplates.get(FR_CONSENT_ORDER_NOT_APPROVED.name())),
-                eq(EMAIL_ADDRESS),
+                eq(TEST_SOLICITOR_EMAIL),
                 eq(expectedEmailTemplateVars),
                 anyString());
     }
@@ -187,6 +189,7 @@ public class EmailServiceTest {
     @Test
     public void sendConsentOrderNotApprovedEmailShouldNotPropagateNotificationClientException()
             throws NotificationClientException {
+
         doThrow(new NotificationClientException(new Exception("Exception inception")))
                 .when(mockClient).sendEmail(anyString(), anyString(), eq(null), anyString());
         try {
@@ -199,6 +202,7 @@ public class EmailServiceTest {
     @Test
     public void sendConsentOrderAvailableEmailShouldCallTheEmailClientToSendAnEmail()
             throws NotificationClientException {
+
         Map<String, String> expectedEmailTemplateVars = getEmailTemplateVars();
         expectedEmailTemplateVars.putAll(emailTemplateVars.get(FR_CONSENT_ORDER_AVAILABLE.name()));
 
@@ -206,7 +210,7 @@ public class EmailServiceTest {
 
         verify(mockClient).sendEmail(
                 eq(emailTemplates.get(FR_CONSENT_ORDER_AVAILABLE.name())),
-                eq(EMAIL_ADDRESS),
+                eq(TEST_SOLICITOR_EMAIL),
                 eq(expectedEmailTemplateVars),
                 anyString());
     }
@@ -228,7 +232,9 @@ public class EmailServiceTest {
         expectedEmailTemplateVars.put("caseReferenceNumber", notificationRequest.getCaseReferenceNumber());
         expectedEmailTemplateVars.put("solicitorReferenceNumber", notificationRequest.getSolicitorReferenceNumber());
         expectedEmailTemplateVars.put("name", notificationRequest.getName());
+
         Map<String, String> courtDetails = contestedContactEmails.get(notificationRequest.getSelectedCourt());
+
         if (!isEmpty(notificationRequest.getSelectedCourt())) {
             expectedEmailTemplateVars.put("courtName", courtDetails.get("name"));
             expectedEmailTemplateVars.put("courtEmail", courtDetails.get("email"));

--- a/src/test/java/uk/gov/hmcts/reform/finrem/notifications/testutil/ObjectMapperTestUtil.java
+++ b/src/test/java/uk/gov/hmcts/reform/finrem/notifications/testutil/ObjectMapperTestUtil.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.reform.finrem.notifications.testutil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ObjectMapperTestUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String convertObjectToJsonString(final Object object) {
+        try {
+            return objectMapper.writeValueAsString(object);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Cleaned up Fin Rem notification service code:
- Bumped dependabot to monthly so we're not spammed with new PRs for updates
- Removed unnecessary vulnerability suppressions
- Introduced notificationConstants file for common constants
- Introduced TestConstants file for common constants
- Removed "convertObjectToJsonString" from multiple files and created 'ObjectMapperTestUtil.java' in Test Utils