### PR TITLE
DFR-1997: decommission service - stop nightly to run [cron('H 22 * * …

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,7 +1,7 @@
 #!groovy
 
 properties([
-        pipelineTriggers([cron('H 22 * * *')]),
+        pipelineTriggers([]),
         parameters([
                 string(name: 'URL_TO_TEST', defaultValue: 'http://finrem-ns-aat.service.core-compute-aat.internal',
                         description: 'The URL you want to run these tests against'),


### PR DESCRIPTION
DFR-1997

decommission service - stop nightly to run 
set cron to empty array instead of [cron('H 22 * * *')]

This service has been absorb in finrem-case-orchestration service